### PR TITLE
support connection to db with custom port, specify dependencies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-06-14  Nattapong Amornbunchornvej  <sprintf.null@gmail.com>
+ Add support for custom port DB connection.
+ Add psycopg2 as dependencies of the python package.
+
 2016-10-08  Kirit Saelensminde  <kirit@felspar.com>
  Added a new module that allows force logout and immediate revokation of JWT.
 

--- a/Python/odin/cmdline.py
+++ b/Python/odin/cmdline.py
@@ -7,10 +7,11 @@ from odin.user import (createuser, expireuser, setfullname, setpassword,
     setsuperuser)
 
 
-SHORTOPTS = '?d:h:U:'
+SHORTOPTS = '?d:h:p:U:'
 PGOPTMAP = {
         '-d': 'dbname',
         '-h': 'host',
+        '-p': 'port',
         '-U': 'user',
     }
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from distutils.core import setup
 
 setup(name='odin',
-        version='0.1.6',
+        version='0.1.6.1',
         description='Odin security system',
         author='Kirt Saelensminde',
         author_email='kirit@proteus-tech.com',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='odin',
         scripts=['Python/bin/odin'],
         packages=['odin'],
         package_dir={'': 'Python'},
+        install_requires=['psycopg2'],
         data_files=[
             ('share/odin/Schema', ['Schema/bootstrap.sql']),
             ('share/odin/Schema/authn', ['Schema/authn/001-initial.blue.sql']),


### PR DESCRIPTION
This pull request support `-p` flag to specify port when PostgreSQL exposes custom port other than 5432.

Also, make `psycopg2` as a dependency so that when using `pip install`, package will be installed together.