### PR TITLE
Use the login API to set the JWT for tests.

### DIFF
--- a/Cpp/include/odin/fg/native.hpp
+++ b/Cpp/include/odin/fg/native.hpp
@@ -19,7 +19,7 @@ namespace odin {
 
     namespace lib {
         const extern fg::frame::builtin assign, expire, group, jwt,
-            membership, permission, superuser, user;
+            jwt_payload, membership, permission, superuser, user;
     }
 
 

--- a/Cpp/include/odin/odin.hpp
+++ b/Cpp/include/odin/odin.hpp
@@ -33,6 +33,9 @@ namespace odin {
     /// SQL `SELECT`, but means that revokation of JWTs won't be noticed.
     extern const fostlib::setting<bool> c_jwt_logout_check;
 
+    /// The JWT claim for embedded permissions
+    extern const fostlib::setting<fostlib::string> c_jwt_permissions_claim;
+
 
 }
 

--- a/Cpp/odin-fg/native.cpp
+++ b/Cpp/odin-fg/native.cpp
@@ -36,6 +36,7 @@ namespace {
             stack.native["odin.assign"] = odin::lib::assign;
             stack.native["odin.group"] = odin::lib::group;
             stack.native["odin.jwt.authorization"] = odin::lib::jwt;
+            stack.native["odin.jwt.payload"] = odin::lib::jwt_payload;
             stack.native["odin.membership"] = odin::lib::membership;
             stack.native["odin.permission"] = odin::lib::permission;
             stack.native["odin.sql.file"] = sql_file;

--- a/Cpp/odin-fg/native.jwt.cpp
+++ b/Cpp/odin-fg/native.jwt.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://odin.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://odin.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -36,5 +36,18 @@ const fg::frame::builtin odin::lib::jwt =
         stack.symbols["testserver.headers"] = headers;
 
         return fg::json(std::move(token));
+    };
+
+
+const fg::frame::builtin odin::lib::jwt_payload =
+    [](fg::frame &stack, fg::json::const_iterator pos, fg::json::const_iterator end) {
+        auto jwt = fostlib::jwt::token::load(
+            odin::c_jwt_secret.value(),
+            fostlib::coerce<fostlib::string>(stack.lookup("odin.jwt")));
+        if ( not jwt ) {
+            return fostlib::json();
+        } else {
+            return jwt.value().payload;
+        }
     };
 

--- a/Cpp/odin-views/login.cpp
+++ b/Cpp/odin-views/login.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://odin.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://odin.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -12,10 +12,14 @@
 #include <odin/views.hpp>
 
 #include <fost/insert>
+#include <fost/log>
 #include <fostgres/sql.hpp>
 
 
 namespace {
+
+
+    const fostlib::module c_odin_login(odin::c_odin, "login.cpp");
 
 
     const class login : public fostlib::urlhandler::view {
@@ -53,6 +57,28 @@ namespace {
                 } else {
                     auto jwt(odin::mint_jwt(user));
                     auto exp = jwt.expires(fostlib::coerce<fostlib::timediff>(config["expires"]), false);
+
+                    if ( config.has_key("permissions") && config["permissions"].isarray() ) {
+                        fostlib::json allowed;
+                        for ( const fostlib::json &perm : config["permissions"] ) {
+                            fostlib::json where;
+                            fostlib::insert(where, "identity_id", username);
+                            fostlib::insert(where, "permission_slug", perm);
+                            auto rs = cnx.select("odin.user_permission", where);
+                            bool granted = rs.begin() != rs.end();
+                            if ( granted ) {
+                                fostlib::push_back(allowed, perm);
+                            }
+                            fostlib::log::debug(c_odin_login)
+                                ("allowed", allowed)
+                                ("granted", granted)
+                                ("permission", perm)
+                                ("where", where);
+                        }
+                        if ( not allowed.isnull() ) {
+                            jwt.claim(odin::c_jwt_permissions_claim.value(), allowed);
+                        }
+                    }
 
                     fostlib::mime::mime_headers headers;
                     headers.add("Expiress", fostlib::coerce<fostlib::rfc1123_timestamp>(exp).underlying().underlying().c_str());

--- a/Cpp/odin-views/permission.cpp
+++ b/Cpp/odin-views/permission.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016 Felspar Co Ltd. http://odin.felspar.com/
+    Copyright 2016-2017 Felspar Co Ltd. http://odin.felspar.com/
     Distributed under the Boost Software License, Version 1.0.
     See accompanying file LICENSE_1_0.txt or copy at
         http://www.boost.org/LICENSE_1_0.txt
@@ -30,6 +30,12 @@ namespace {
         ) const {
             fostlib::pg::connection cnx{fostgres::connection(config, req)};
             fostlib::json where;
+            if ( not req[userloc] ) {
+                throw fostlib::exceptions::not_implemented(__func__,
+                    "The odin.permission view must be wrapped by an odin.secure "
+                    "view on the secure path so that there is a valid JWT to find "
+                    "the user ID in");
+            }
             fostlib::insert(where, "identity_id", req[userloc].value());
             fostlib::insert(where, "permission_slug", config["permission"]);
             auto rs = cnx.select("odin.user_permission", where);

--- a/Cpp/odin/odin.cpp
+++ b/Cpp/odin/odin.cpp
@@ -24,6 +24,9 @@ const fostlib::setting<fostlib::string> odin::c_jwt_logout_claim(
 const fostlib::setting<bool> odin::c_jwt_logout_check(
     "odin/odin.cpp", "odin", "Perform JWT logout check", true, true);
 
+const fostlib::setting<fostlib::string> odin::c_jwt_permissions_claim(
+    "odin/odin.cpp", "odin", "JWT permissions claim", "http://odin.felspar.com/p", true);
+
 
 namespace {
     const fostgres::register_cnx_callback c_cb(

--- a/tests/Jamfile
+++ b/tests/Jamfile
@@ -6,6 +6,7 @@ run ../../fostgres/Cpp/fostgres-test//fostgres-test :
         ../Cpp/odin-fg//odin-fg
         ../Cpp/odin-views//odin-views
         ../Schema/bootstrap.sql
+        authnz-test-view.json
         authnz.fg
     :
     :

--- a/tests/Jamfile
+++ b/tests/Jamfile
@@ -1,4 +1,18 @@
 run ../../fostgres/Cpp/fostgres-test//fostgres-test :
+        odin-test-authnz
+    :
+        ../../fost-web/Configuration/log-show-all.json
+        ../Configuration/odin-views.json
+        ../Cpp/odin-fg//odin-fg
+        ../Cpp/odin-views//odin-views
+        ../Schema/bootstrap.sql
+        authnz.fg
+    :
+    :
+        odin-test-authnz
+    ;
+
+run ../../fostgres/Cpp/fostgres-test//fostgres-test :
         odin-test-db-bypass
     :
         ../../fost-web/Configuration/log-show-all.json

--- a/tests/authnz-test-view.json
+++ b/tests/authnz-test-view.json
@@ -4,6 +4,7 @@
             "view": "odin.login",
             "configuration": {
                 "expires": {"hours": 72},
+                "permissions": ["p2", "p1", "p404"],
                 "failure": {
                     "view": "fost.response.401",
                     "configuration": {

--- a/tests/authnz-test-view.json
+++ b/tests/authnz-test-view.json
@@ -14,6 +14,69 @@
                     }
                 }
             }
+        },
+        "views/odin/test/p1": {
+            "view": "odin.secure",
+            "configuration": {
+                "secure": {
+                    "view": "odin.permission",
+                    "configuration": {
+                        "permission": "p1",
+                        "allowed": "fost.response.200",
+                        "forbidden": "fost.response.403"
+                    }
+                },
+                "unsecure": {
+                    "view": "fost.response.401",
+                    "configuration": {
+                        "schemes": {
+                            "Bearer": {}
+                        }
+                    }
+                }
+            }
+        },
+        "views/odin/test/p2": {
+            "view": "odin.secure",
+            "configuration": {
+                "secure": {
+                    "view": "odin.permission",
+                    "configuration": {
+                        "permission": "p2",
+                        "allowed": "fost.response.200",
+                        "forbidden": "fost.response.403"
+                    }
+                },
+                "unsecure": {
+                    "view": "fost.response.401",
+                    "configuration": {
+                        "schemes": {
+                            "Bearer": {}
+                        }
+                    }
+                }
+            }
+        },
+        "views/odin/test/p3": {
+            "view": "odin.secure",
+            "configuration": {
+                "secure": {
+                    "view": "odin.permission",
+                    "configuration": {
+                        "permission": "p3",
+                        "allowed": "fost.response.200",
+                        "forbidden": "fost.response.403"
+                    }
+                },
+                "unsecure": {
+                    "view": "fost.response.401",
+                    "configuration": {
+                        "schemes": {
+                            "Bearer": {}
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/authnz-test-view.json
+++ b/tests/authnz-test-view.json
@@ -1,0 +1,18 @@
+{
+    "webserver": {
+        "views/odin/test/authnz": {
+            "view": "odin.login",
+            "configuration": {
+                "expires": {"hours": 72},
+                "failure": {
+                    "view": "fost.response.401",
+                    "configuration": {
+                        "schemes": {
+                            "Bearer": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/authnz.fg
+++ b/tests/authnz.fg
@@ -2,6 +2,7 @@
 odin.sql.file (module.path.join ../Schema/core/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/authz/001-initial.blue.sql)
+setting odin "Trust JWT" true
 odin.user test password1234
 odin.permission p1
 odin.permission p2
@@ -15,11 +16,24 @@ set odin.jwt (POST odin/test/authnz / {"username": "test", "password": "password
 set-path testserver.headers (Authorization) (cat "Bearer " (lookup odin.jwt))
 GET odin/api / 200
 
-# Blank the header and it will fail again
+# Blank the header and it will fail again, then set it back up properly
 set-path testserver.headers (Authorization) ""
 GET odin/api / 401
 
 # Check that the default JWT contains the subject key
 set payload (odin.jwt.payload)
 contains (lookup payload) {"sub": "test", "http://odin.felspar.com/p": ["p1"]}
+
+# Check that the database controls access to the APIs
+odin.jwt.authorization test password1234 # No permissions claim in JWT
+GET odin/test/p1 / 200
+GET odin/test/p2 / 403
+GET odin/test/p3 / 200
+
+# Add p2 explicitly into the payload. When this is checked we will have
+# access to the API even though we don't have the permission in the database
+odin.jwt.authorization test password1234 {"http://odin.felspar.com/p": ["p2"]}
+GET odin/test/p1 / 200
+GET odin/test/p2 / 200
+GET odin/test/p3 / 200
 

--- a/tests/authnz.fg
+++ b/tests/authnz.fg
@@ -1,0 +1,10 @@
+# Set up the database
+odin.sql.file (module.path.join ../Schema/core/001-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authz/001-initial.blue.sql)
+odin.user test password1234
+
+# Use the login API to get our JWT and then check it works
+set odin.jwt (POST odin/login / {"username": "test", "password": "password1234"} 200)
+set-path testserver.headers (Authorization) (cat "Bearer " (lookup odin.jwt))
+GET odin/api / 200

--- a/tests/authnz.fg
+++ b/tests/authnz.fg
@@ -3,9 +3,15 @@ odin.sql.file (module.path.join ../Schema/core/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/authz/001-initial.blue.sql)
 odin.user test password1234
+odin.permission p1
+odin.permission p2
+odin.permission p3
+odin.group g1
+odin.assign g1 p1 p3
+odin.membership test g1
 
 # Use the login API to get our JWT and then check it works
-set odin.jwt (POST odin/login / {"username": "test", "password": "password1234"} 200)
+set odin.jwt (POST odin/test/authnz / {"username": "test", "password": "password1234"} 200)
 set-path testserver.headers (Authorization) (cat "Bearer " (lookup odin.jwt))
 GET odin/api / 200
 
@@ -15,4 +21,5 @@ GET odin/api / 401
 
 # Check that the default JWT contains the subject key
 set payload (odin.jwt.payload)
-contains (lookup payload) {"sub": "test"}
+contains (lookup payload) {"sub": "test", "http://odin.felspar.com/p": ["p1"]}
+

--- a/tests/authnz.fg
+++ b/tests/authnz.fg
@@ -8,3 +8,11 @@ odin.user test password1234
 set odin.jwt (POST odin/login / {"username": "test", "password": "password1234"} 200)
 set-path testserver.headers (Authorization) (cat "Bearer " (lookup odin.jwt))
 GET odin/api / 200
+
+# Blank the header and it will fail again
+set-path testserver.headers (Authorization) ""
+GET odin/api / 401
+
+# Check that the default JWT contains the subject key
+set payload (odin.jwt.payload)
+contains (lookup payload) {"sub": "test"}

--- a/tests/permissions.json
+++ b/tests/permissions.json
@@ -10,9 +10,6 @@
                         "create-group/": {
                             "view": "odin.permission",
                             "configuration": {
-                                "host": ["request", "headers", "__pgdsn", "host"],
-                                "user": ["request", "headers", "__pgdsn", "user"],
-                                "dbname": ["request", "headers", "__pgdsn", "dbname"],
                                 "permission": "create-group",
                                 "allowed": "odin/secure/sql",
                                 "forbidden": "fost.response.403"
@@ -21,9 +18,6 @@
                         "not-granted/": {
                             "view": "odin.permission",
                             "configuration": {
-                                "host": ["request", "headers", "__pgdsn", "host"],
-                                "user": ["request", "headers", "__pgdsn", "user"],
-                                "dbname": ["request", "headers", "__pgdsn", "dbname"],
                                 "permission": "not-granted",
                                 "allowed": "odin/secure/sql",
                                 "forbidden": "fost.response.403"


### PR DESCRIPTION
Again, just a start here so far. This shows that the JWT generated by the login API can be captured and used in subsequent requests.