### PR TITLE
Fixed facebook login failed when email or full name is null

### DIFF
--- a/Cpp/odin-views/facebook.cpp
+++ b/Cpp/odin-views/facebook.cpp
@@ -52,7 +52,7 @@ namespace {
                     // Use access token as facebook ID
                     fostlib::insert(user_detail, "id", access_token);
                     fostlib::insert(user_detail, "name", "Test User");
-                    fostlib::insert(user_detail, "email", access_token + "@mail.com");
+                    fostlib::insert(user_detail, "email", access_token + "@example.com");
                 }
             } else {
                 user_detail = odin::facebook::get_user_detail(access_token);


### PR DESCRIPTION
Login with Facebook failed when the user does not grant the permission to view email or full name.
Also fixed `facebook-mock` that will break the view if not added in view configuration.