### PR TITLE
Feature/improve social error message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 2018-08-16  Tle Ekkul  <e.aryuth@gmail.com>
- Returned BadRequest when user's email already exists in the system.
+ Returned Unprocessable Entity when user's email already exists in the system.
 
 2018-08-12  Tle Ekkul  <e.aryuth@gmail.com>
  Added Login with Odin page

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-08-16  Tle Ekkul  <e.aryuth@gmail.com>
+ Returned BadRequest when user's email already exists in the system.
+
 2018-08-12  Tle Ekkul  <e.aryuth@gmail.com>
  Added Login with Odin page
 

--- a/Cpp/include/odin/user.hpp
+++ b/Cpp/include/odin/user.hpp
@@ -44,5 +44,7 @@ namespace odin {
     void set_email(fostlib::pg::connection &cnx, f5::u8view reference, f5::u8view username,
         fostlib::email_address email);
 
+    /// Check email already exists in the database
+    bool does_email_exist(fostlib::pg::connection &cnx, fostlib::string email);
 
 }

--- a/Cpp/odin-views/facebook.cpp
+++ b/Cpp/odin-views/facebook.cpp
@@ -85,7 +85,7 @@ namespace {
                 if ( user_detail.has_key("email") ) {
                     const auto facebook_user_email = fostlib::coerce<fostlib::email_address>(user_detail["email"]);
                     if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(user_detail["email"])) ) {
-                        return respond("This email already exists", 400);
+                        return respond("This email already exists", 422);
                     }
                     odin::set_email(cnx, reference, identity_id, facebook_user_email);
                 }

--- a/Cpp/odin-views/facebook.cpp
+++ b/Cpp/odin-views/facebook.cpp
@@ -85,7 +85,7 @@ namespace {
                 if ( user_detail.has_key("email") ) {
                     const auto facebook_user_email = fostlib::coerce<fostlib::email_address>(user_detail["email"]);
                     if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(user_detail["email"])) ) {
-                        return respond("This email has been used", 400);
+                        return respond("This email already exists", 400);
                     }
                     odin::set_email(cnx, reference, identity_id, facebook_user_email);
                 }

--- a/Cpp/odin-views/google.cpp
+++ b/Cpp/odin-views/google.cpp
@@ -85,7 +85,7 @@ namespace {
                 if ( user_detail.has_key("email") ) {
                     const auto google_user_email = fostlib::coerce<fostlib::email_address>(user_detail["email"]);
                     if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(user_detail["email"])) ) {
-                        return respond("This email already exists", 400);
+                        return respond("This email already exists", 422);
                     }
                     odin::set_email(cnx, reference, identity_id, google_user_email);
                 }

--- a/Cpp/odin-views/google.cpp
+++ b/Cpp/odin-views/google.cpp
@@ -23,6 +23,17 @@ namespace {
 
     const fostlib::module c_odin_google(odin::c_odin, "google.cpp");
 
+    std::pair<boost::shared_ptr<fostlib::mime>, int> respond(
+        fostlib::string message, int code=403
+    ) {
+        fostlib::json ret;
+        if ( not message.empty() ) fostlib::insert(ret, "message", std::move(message));
+        fostlib::mime::mime_headers headers;
+        boost::shared_ptr<fostlib::mime> response(
+            new fostlib::text_body(fostlib::json::unparse(ret, true), headers, "application/json"));
+        return std::make_pair(response, code);
+    }
+
     const class google : public fostlib::urlhandler::view {
     public:
         google()
@@ -52,7 +63,7 @@ namespace {
                     // Use access token as google ID
                     fostlib::insert(user_detail, "sub", access_token);
                     fostlib::insert(user_detail, "name", "Test User");
-                    fostlib::insert(user_detail, "email", access_token + "@mail.com");
+                    fostlib::insert(user_detail, "email", access_token + "@example.com");
                 }
             } else {
                 user_detail = odin::google::get_user_detail(access_token);
@@ -73,6 +84,9 @@ namespace {
                 }
                 if ( user_detail.has_key("email") ) {
                     const auto google_user_email = fostlib::coerce<fostlib::email_address>(user_detail["email"]);
+                    if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(user_detail["email"])) ) {
+                        return respond("This email already exists", 400);
+                    }
                     odin::set_email(cnx, reference, identity_id, google_user_email);
                 }
             } else {

--- a/Cpp/odin-views/registration.cpp
+++ b/Cpp/odin-views/registration.cpp
@@ -21,6 +21,17 @@ namespace {
 
     const fostlib::module c_odin_registration(odin::c_odin, "registration.cpp");
 
+    std::pair<boost::shared_ptr<fostlib::mime>, int> respond(
+        fostlib::string message, int code=403
+    ) {
+        fostlib::json ret;
+        if ( not message.empty() ) fostlib::insert(ret, "message", std::move(message));
+        fostlib::mime::mime_headers headers;
+        boost::shared_ptr<fostlib::mime> response(
+            new fostlib::text_body(fostlib::json::unparse(ret, true), headers, "application/json"));
+        return std::make_pair(response, code);
+    }
+
     const class registration : public fostlib::urlhandler::view {
     public:
         registration()
@@ -79,6 +90,9 @@ namespace {
             if ( body.has_key("email") ) {
                 try {
                     const auto email = fostlib::coerce<fostlib::email_address>(body["email"]);
+                    if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(body["email"])) ) {
+                        return respond("This email already exists", 400);
+                    }
                     odin::set_email(cnx, ref, username.value(), email);
                 } catch ( fostlib::exceptions::parse_error &e ) {
                     fostlib::log::error(c_odin_registration)

--- a/Cpp/odin-views/registration.cpp
+++ b/Cpp/odin-views/registration.cpp
@@ -91,7 +91,7 @@ namespace {
                 try {
                     const auto email = fostlib::coerce<fostlib::email_address>(body["email"]);
                     if ( odin::does_email_exist(cnx, fostlib::coerce<fostlib::string>(body["email"])) ) {
-                        return respond("This email already exists", 400);
+                        return respond("This email already exists", 422);
                     }
                     odin::set_email(cnx, ref, username.value(), email);
                 } catch ( fostlib::exceptions::parse_error &e ) {

--- a/Cpp/odin/user.cpp
+++ b/Cpp/odin/user.cpp
@@ -104,7 +104,7 @@ void odin::set_email(
 
 
 bool odin::does_email_exist(fostlib::pg::connection &cnx, fostlib::string email) {
-    static const fostlib::string sql("SELECT * FROM odin.identity WHERE email=$1");
+    static const fostlib::string sql("SELECT email FROM odin.identity WHERE email=$1");
     auto data = fostgres::sql(cnx, sql, std::vector<fostlib::string>{email});
     auto &rs = data.second;
     return rs.begin() != rs.end();

--- a/Cpp/odin/user.cpp
+++ b/Cpp/odin/user.cpp
@@ -101,3 +101,11 @@ void odin::set_email(
     fostlib::insert(user_values, "email", email.email());
     cnx.insert("odin.identity_email_ledger", user_values);
 }
+
+
+bool odin::does_email_exist(fostlib::pg::connection &cnx, fostlib::string email) {
+    static const fostlib::string sql("SELECT * FROM odin.identity WHERE email=$1");
+    auto data = fostgres::sql(cnx, sql, std::vector<fostlib::string>{email});
+    auto &rs = data.second;
+    return rs.begin() != rs.end();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -149,6 +149,8 @@ add_custom_command(OUTPUT test-registration-self
             $<TARGET_SONAME_FILE:odin-views>
             ${CMAKE_CURRENT_SOURCE_DIR}/../Schema/bootstrap.sql
             ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/odin-views.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/login-google-test.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/facebook-test.json
             ${CMAKE_CURRENT_SOURCE_DIR}/registration-self.fg
         MAIN_DEPENDENCY registration-self.fg
         DEPENDS
@@ -162,6 +164,8 @@ add_custom_command(OUTPUT test-registration-self
             ../Schema/opts/full-name/001-initial.blue.sql
             ../Schema/opts/email/001-initial.blue.sql
             ../Configuration/odin-views.json
+            login-google-test.json
+            facebook-test.json
             registration-self.fg
     )
 
@@ -217,6 +221,7 @@ add_custom_command(OUTPUT test-login-facebook
             ${CMAKE_CURRENT_SOURCE_DIR}/../Schema/bootstrap.sql
             ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/odin-views.json
             ${CMAKE_CURRENT_SOURCE_DIR}/facebook-test.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/login-google-test.json
             ${CMAKE_CURRENT_SOURCE_DIR}/login-facebook.fg
         MAIN_DEPENDENCY login-facebook.fg
         DEPENDS
@@ -232,6 +237,7 @@ add_custom_command(OUTPUT test-login-facebook
             ../Schema/opts/full-name/001-initial.blue.sql
             ../Configuration/odin-views.json
             facebook-test.json
+            login-google-test.json
             login-facebook.fg
     )
 
@@ -268,6 +274,7 @@ add_custom_command(OUTPUT test-login-google
             ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/odin-views.json
             ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/odin-webserver.json
             ${CMAKE_CURRENT_SOURCE_DIR}/login-google-test.json
+            ${CMAKE_CURRENT_SOURCE_DIR}/facebook-test.json
             ${CMAKE_CURRENT_SOURCE_DIR}/login-google.fg
         MAIN_DEPENDENCY login-google.fg
         DEPENDS
@@ -283,6 +290,7 @@ add_custom_command(OUTPUT test-login-google
             ../Schema/opts/full-name/001-initial.blue.sql
             ../Configuration/odin-views.json
             login-google-test.json
+            facebook-test.json
             login-google.fg
     )
 

--- a/tests/login-facebook.fg
+++ b/tests/login-facebook.fg
@@ -1,5 +1,6 @@
 # Set up the database
 odin.sql.file (module.path.join ../Schema/core/000-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/full-name/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/email/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/facebook/001-initial.blue.sql)
@@ -23,3 +24,6 @@ POST odin/test/facebook/login/ok / {"access_token": "user_2"} 200
 GET odin/test/facebook/validate_login /count-users 200 {"count": 2}
 GET odin/test/facebook/validate_login /count-facebook-users 200 {"count": 2}
 
+# If user email is already exists in Odin, return 400 with error message
+POST odin/register / {"username": "exist_user", "password": "password1234", "email": "exist_user@example.com"} 201
+POST odin/test/facebook/login/ok / {"access_token": "exist_user"} 400 {"message": "This email has been used"}

--- a/tests/login-facebook.fg
+++ b/tests/login-facebook.fg
@@ -24,6 +24,10 @@ POST odin/test/facebook/login/ok / {"access_token": "user_2"} 200
 GET odin/test/facebook/validate_login /count-users 200 {"count": 2}
 GET odin/test/facebook/validate_login /count-facebook-users 200 {"count": 2}
 
-# If user email is already exists in Odin, return 400 with error message
+# If user already registered with Odin, return 400 with error message
 POST odin/register / {"username": "exist_user", "password": "password1234", "email": "exist_user@example.com"} 201
-POST odin/test/facebook/login/ok / {"access_token": "exist_user"} 400 {"message": "This email has been used"}
+POST odin/test/facebook/login/ok / {"access_token": "exist_user"} 400 {"message": "This email already exists"}
+
+odin.sql.file (module.path.join ../Schema/opts/google/001-initial.blue.sql)
+POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 200
+POST odin/test/facebook/login/ok / {"access_token": "login_via_gp"} 400 {"message": "This email already exists"}

--- a/tests/login-facebook.fg
+++ b/tests/login-facebook.fg
@@ -24,10 +24,10 @@ POST odin/test/facebook/login/ok / {"access_token": "user_2"} 200
 GET odin/test/facebook/validate_login /count-users 200 {"count": 2}
 GET odin/test/facebook/validate_login /count-facebook-users 200 {"count": 2}
 
-# If user already registered with Odin, return 400 with error message
+# If user already registered with Odin, return 422 with error message
 POST odin/register / {"username": "exist_user", "password": "password1234", "email": "exist_user@example.com"} 201
-POST odin/test/facebook/login/ok / {"access_token": "exist_user"} 400 {"message": "This email already exists"}
+POST odin/test/facebook/login/ok / {"access_token": "exist_user"} 422 {"message": "This email already exists"}
 
 odin.sql.file (module.path.join ../Schema/opts/google/001-initial.blue.sql)
 POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 200
-POST odin/test/facebook/login/ok / {"access_token": "login_via_gp"} 400 {"message": "This email already exists"}
+POST odin/test/facebook/login/ok / {"access_token": "login_via_gp"} 422 {"message": "This email already exists"}

--- a/tests/login-google.fg
+++ b/tests/login-google.fg
@@ -1,5 +1,6 @@
 # Set up the database
 odin.sql.file (module.path.join ../Schema/core/000-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/full-name/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/email/001-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/opts/google/001-initial.blue.sql)
@@ -32,3 +33,10 @@ POST odin/test/google/login/ok / {"access_token": "user_2"} 200
 GET odin/test/google/validate_login /count-users 200 {"count": 2}
 GET odin/test/google/validate_login /count-google-users 200 {"count": 2}
 
+# If user already registered with Odin, return 400 with error message
+POST odin/register / {"username": "exist_user", "password": "password1234", "email": "exist_user@example.com"} 201
+POST odin/test/google/login/ok / {"access_token": "exist_user"} 400 {"message": "This email already exists"}
+
+odin.sql.file (module.path.join ../Schema/opts/facebook/001-initial.blue.sql)
+POST odin/test/facebook/login/ok / {"access_token": "login_via_gp"} 200
+POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 400 {"message": "This email already exists"}

--- a/tests/login-google.fg
+++ b/tests/login-google.fg
@@ -33,10 +33,10 @@ POST odin/test/google/login/ok / {"access_token": "user_2"} 200
 GET odin/test/google/validate_login /count-users 200 {"count": 2}
 GET odin/test/google/validate_login /count-google-users 200 {"count": 2}
 
-# If user already registered with Odin, return 400 with error message
+# If user already registered with Odin, return 422 with error message
 POST odin/register / {"username": "exist_user", "password": "password1234", "email": "exist_user@example.com"} 201
-POST odin/test/google/login/ok / {"access_token": "exist_user"} 400 {"message": "This email already exists"}
+POST odin/test/google/login/ok / {"access_token": "exist_user"} 422 {"message": "This email already exists"}
 
 odin.sql.file (module.path.join ../Schema/opts/facebook/001-initial.blue.sql)
 POST odin/test/facebook/login/ok / {"access_token": "login_via_gp"} 200
-POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 400 {"message": "This email already exists"}
+POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 422 {"message": "This email already exists"}

--- a/tests/login.fg
+++ b/tests/login.fg
@@ -20,4 +20,3 @@ POST odin/login / {"username": "tester", "password": "password1234"} 401
 # Expire the user and make sure they can't now log in
 odin.user.expire test
 POST odin/login / {"username": "test", "password": "password1234"} 401
-

--- a/tests/registration-self.fg
+++ b/tests/registration-self.fg
@@ -50,4 +50,13 @@ POST odin/register / {"username": "user91", "password": "password1234", "email":
 POST odin/register / {"username": "user91", "password": "password1234", "email": ""} 501
 
 ## Should throw exception when user input existing email
-POST odin/register / {"username": "user90", "password": "password1234", "email": "admin@example.com"} 501
+POST odin/register / {"username": "user90", "password": "password1234", "email": "admin@example.com"} 400 {"message": "This email already exists"}
+
+# If user already registered with Odin, return 400 with error message
+odin.sql.file (module.path.join ../Schema/opts/google/001-initial.blue.sql)
+POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 200
+POST odin/register / {"username": "login_via_gp", "password": "password1234", "email": "login_via_gp@example.com"} 400 {"message": "This email already exists"}
+
+odin.sql.file (module.path.join ../Schema/opts/facebook/001-initial.blue.sql)
+POST odin/test/facebook/login/ok / {"access_token": "login_via_fb"} 200
+POST odin/register / {"username": "login_via_fb", "password": "password1234", "email": "login_via_fb@example.com"} 400 {"message": "This email already exists"}

--- a/tests/registration-self.fg
+++ b/tests/registration-self.fg
@@ -50,13 +50,13 @@ POST odin/register / {"username": "user91", "password": "password1234", "email":
 POST odin/register / {"username": "user91", "password": "password1234", "email": ""} 501
 
 ## Should throw exception when user input existing email
-POST odin/register / {"username": "user90", "password": "password1234", "email": "admin@example.com"} 400 {"message": "This email already exists"}
+POST odin/register / {"username": "user90", "password": "password1234", "email": "admin@example.com"} 422 {"message": "This email already exists"}
 
-# If user already registered with Odin, return 400 with error message
+# If user already registered with Odin, return 422 with error message
 odin.sql.file (module.path.join ../Schema/opts/google/001-initial.blue.sql)
 POST odin/test/google/login/ok / {"access_token": "login_via_gp"} 200
-POST odin/register / {"username": "login_via_gp", "password": "password1234", "email": "login_via_gp@example.com"} 400 {"message": "This email already exists"}
+POST odin/register / {"username": "login_via_gp", "password": "password1234", "email": "login_via_gp@example.com"} 422 {"message": "This email already exists"}
 
 odin.sql.file (module.path.join ../Schema/opts/facebook/001-initial.blue.sql)
 POST odin/test/facebook/login/ok / {"access_token": "login_via_fb"} 200
-POST odin/register / {"username": "login_via_fb", "password": "password1234", "email": "login_via_fb@example.com"} 400 {"message": "This email already exists"}
+POST odin/register / {"username": "login_via_fb", "password": "password1234", "email": "login_via_fb@example.com"} 422 {"message": "This email already exists"}


### PR DESCRIPTION
Return 400 BadRequest when the user is trying to register with existing email.
This will make the client be able to tell the user whether they already login with another login type
