### PR TITLE
Feature/federation client improvement

### DIFF
--- a/Cpp/odin-views/app.cpp
+++ b/Cpp/odin-views/app.cpp
@@ -136,6 +136,16 @@ namespace {
             fostlib::pg::connection cnx{fostgres::connection(config, req)};
             auto ref = odin::reference();
             odin::create_user(cnx, ref, fostlib::coerce<fostlib::string>(fed_response_data["identity"]["id"]));
+            if ( odin::is_module_enabled(cnx, "opts/full-name") ){
+                odin::set_full_name(cnx, ref,
+                    fostlib::coerce<fostlib::string>(fed_response_data["identity"]["id"]),
+                    fostlib::coerce<fostlib::string>(fed_response_data["identity"]["full_name"]));
+            }
+            if ( odin::is_module_enabled(cnx, "opts/email") ){
+                odin::set_email(cnx, ref,
+                    fostlib::coerce<fostlib::string>(fed_response_data["identity"]["id"]),
+                    fostlib::coerce<fostlib::email_address>(fed_response_data["identity"]["email"]));
+            }
             cnx.commit();
             auto jwt(odin::mint_login_jwt(fed_response_data));
             auto exp = jwt.expires(fostlib::coerce<fostlib::timediff>(config["expires"]), false);

--- a/Static/app/CMakeLists.txt
+++ b/Static/app/CMakeLists.txt
@@ -1,4 +1,4 @@
 install(FILES
     login.html
     logged_in.html
-DESTINATION usr/share/odin/Static/app)
+DESTINATION share/odin/Static/app)

--- a/tests/app-handover.fg
+++ b/tests/app-handover.fg
@@ -19,3 +19,12 @@ POST test/app/handover / {} 501
 
 POST test/app/handover / {"token": "mock"} 200
 GET test/app/handover/validate /mock_user 200 {"id": "mock_user"}
+
+# Should record identity data if modules are enabled
+odin.sql.file (module.path.join ../Schema/opts/full-name/001-initial.blue.sql)
+POST test/app/handover / {"token": "mock"} 200
+GET test/app/handover/validate /mock_user 200 {"id": "mock_user", "full_name": "Mock User"}
+
+odin.sql.file (module.path.join ../Schema/opts/email/001-initial.blue.sql)
+POST test/app/handover / {"token": "mock"} 200
+GET test/app/handover/validate /mock_user 200 {"id": "mock_user", "full_name": "Mock User", "email": "mock_user@email.com"}


### PR DESCRIPTION
The current version, we record only `identity_id`. This PR will check the odin federation client modules and record identity data if enabled.