### PR TITLE
Feature/app secure improvement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-11-08  Tle Ekkul  <e.aryuth@gmail.com>
+ odin.app.secure doesn't need app_id as a prefix anymore.
+
 2018-11-02  Tle Ekkul  <e.aryuth@gmail.com>
  Fix table app_user PK order
  Add table app_role_ledger

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -31,38 +31,29 @@ namespace {
             fostlib::http::server::request &req,
             const fostlib::host &host
         ) const {
-            fostlib::log::debug(odin::c_odin)("path", path);
-            const auto slash = path.find("/");
-            const auto app_id = path.substr(0, slash);
-            if ( app_id.empty() )
-                throw fostlib::exceptions::not_implemented(__func__,
-                    "Must pass app_id in the URL");
-
-            fostlib::pg::connection cnx{fostgres::connection(config, req)};
-            fostlib::json app = odin::app::get_detail(cnx, app_id);
-            if ( app.isnull() )
-                throw fostlib::exceptions::not_implemented(__func__, "App not found");
-            // Set the reference header
-            auto ref = odin::reference();
-            req.headers().set("__odin_reference", ref);
-            // Now check which sub-view to enter
             if ( req.headers().exists("Authorization") ) {
                 auto parts = fostlib::partition(req.headers()["Authorization"].value(), " ");
                 if ( parts.first == "Bearer" && parts.second ) {
+                    fostlib::pg::connection cnx{fostgres::connection(config, req)};
                     auto jwt = fostlib::jwt::token::load(
-                        fostlib::coerce<fostlib::string>(app["app"]["token"]), parts.second.value());
+                        [&cnx = cnx] (fostlib::json jwt_header, fostlib::json jwt_body) {
+                            const auto app_id = fostlib::coerce<fostlib::string>(jwt_body["iss"]);
+                            fostlib::json app = odin::app::get_detail(cnx, std::move(app_id));
+                            if ( app.isnull() ) {
+                                throw fostlib::exceptions::not_implemented(__PRETTY_FUNCTION__, "App not found");
+                            }
+                            return fostlib::coerce<fostlib::string>(app["app"]["token"]);
+                        }, parts.second.value());
                     if ( jwt ) {
                         auto iss = fostlib::coerce<fostlib::string>(jwt.value().payload["iss"]);
-                        if ( iss == app_id ) {
-                            fostlib::log::debug(odin::c_odin)
-                                ("", "JWT authenticated")
-                                ("header", jwt.value().header)
-                                ("payload", jwt.value().payload);
-                            req.headers().set("__jwt", jwt.value().payload, "sub");
-                            req.headers().set("__app",
-                                fostlib::coerce<fostlib::string>(jwt.value().payload["iss"]));
-                            return execute(config["secure"], slash == fostlib::string::npos ? fostlib::string{} : path.substr(slash + 1), req, host);
-                        }
+                        fostlib::log::debug(odin::c_odin)
+                            ("", "JWT authenticated")
+                            ("header", jwt.value().header)
+                            ("payload", jwt.value().payload);
+                        req.headers().set("__jwt", jwt.value().payload, "sub");
+                        req.headers().set("__user", fostlib::coerce<fostlib::string>(jwt.value().payload["sub"]));
+                        req.headers().set("__app", fostlib::coerce<fostlib::string>(jwt.value().payload["iss"]));
+                        return execute(config["secure"], path, req, host);
                     }
                 } else {
                     fostlib::log::warning(odin::c_odin)

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -36,7 +36,7 @@ namespace {
                 if ( parts.first == "Bearer" && parts.second ) {
                     fostlib::pg::connection cnx{fostgres::connection(config, req)};
                     auto jwt = fostlib::jwt::token::load(
-                        [&cnx = cnx] (fostlib::json jwt_header, fostlib::json jwt_body) {
+                        [&cnx] (fostlib::json jwt_header, fostlib::json jwt_body) {
                             const auto app_id = fostlib::coerce<fostlib::string>(jwt_body["iss"]);
                             fostlib::json app = odin::app::get_detail(cnx, std::move(app_id));
                             if ( app.isnull() ) {

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -11,17 +11,17 @@ odin.user player2 password1234
 odin.user player3 password1234
 odin.sql.file (module.path.join app-login-test-figure.sql)
 
-GET test/app/secure / 501
-GET test/app/secure /random-app 501
-
-GET test/app/secure /app01 401
-
+GET test/app/secure / 401
 
 # Mint App jwt
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "app01"} APP_TOKEN)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
-GET test/app/secure /app02 401
-GET test/app/secure /app01 200
-GET test/app/secure /app01/ 200
+GET test/app/secure / 200
+GET test/app/secure /test 200
 
-GET test/app/secure /app01/test 200
+# Wrong App jwt should return 401
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "app02"} APP_TOKEN)
+set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
+GET test/app/secure / 401
+GET test/app/secure /test 401
+


### PR DESCRIPTION
- Changed the way we get <app_id> to get it from JWT payload instead.
- `odin.app.secure` doesn't require prefix anymore.