### PR TITLE
Feature/fix wrong jwt secret

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-01-09  Tle Ekkul  <e.aryuth@gmail.com>
+  Remove usage of app token
+
 2018-12-27  Tle Ekkul  <e.aryuth@gmail.com>
   Fix AuthN login schema
 

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -51,8 +51,7 @@ namespace {
             throw fostlib::exceptions::not_implemented(
                     __PRETTY_FUNCTION__, "App not found");
         }
-        auto const app_token =
-                fostlib::coerce<fostlib::string>(app["app"]["token"]);
+        auto const app_token = odin::c_jwt_secret.value() + app_id;
         return std::vector<f5::byte>(
                 app_token.data().begin(), app_token.data().end());
     }

--- a/Cpp/odin-views/facebook.cpp
+++ b/Cpp/odin-views/facebook.cpp
@@ -209,8 +209,8 @@ namespace {
             if (!facebook_user.isnull()) {
                 if (identity_id
                     == fostlib::coerce<fostlib::string>(
-                            facebook_user["facebook_credentials"]
-                                         ["identity_id"])) {
+                               facebook_user["facebook_credentials"]
+                                            ["identity_id"])) {
                     throw fostlib::exceptions::not_implemented(
                             "odin.facebook.link",
                             "This user already linked to this facebook");

--- a/Cpp/odin-views/password.cpp
+++ b/Cpp/odin-views/password.cpp
@@ -167,7 +167,7 @@ namespace {
             auto jwt = fostlib::jwt::token::load(
                     odin::c_jwt_reset_forgotten_password_secret.value()
                             + fostlib::coerce<fostlib::string>(
-                                    user["password"]["hash"]),
+                                      user["password"]["hash"]),
                     reset_token);
             if (not jwt) { return respond("Invalid token", 403); }
             auto username =

--- a/tests/app-installation-test.json
+++ b/tests/app-installation-test.json
@@ -7,6 +7,20 @@
                     "hours": 72
                 }
             }
+        },
+        "views/test/app/installation/validate": {
+            "view": "odin.app.secure",
+            "configuration": {
+                "secure": "fost.response.200",
+                "unsecure": {
+                    "view": "fost.response.401",
+                    "configuration": {
+                        "schemes": {
+                            "Bearer": {}
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/app-installation.fg
+++ b/tests/app-installation.fg
@@ -57,3 +57,10 @@ sql.insert odin.app_user_installation_id_ledger {
 POST test/app/installation / {"installation_id": "claimed-installation"} 501
 
 POST test/app/installation / {"installation_id": "new-installation"} 201
+
+# odin should accept the JWT that minted by app.installation view
+set-path testserver.headers ["__app"] ""
+
+set app_jwt (odin.jwt.mint {"sub": "installation_ref", "iss": "http://odin.felspar.com/app/open-app"} <JWT_SECRET>open-app)
+set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
+GET test/app/installation/validate / 200

--- a/tests/app-secure-test-view.json
+++ b/tests/app-secure-test-view.json
@@ -1,4 +1,7 @@
 {
+    "odin": {
+        "JWT secret": "<JWT_SECRET>"
+    },
     "webserver": {
         "views/test/app/secure": {
             "view": "odin.app.secure",

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -39,13 +39,13 @@ sql.insert odin.app_ledger {
 GET test/app/secure / 401
 
 # Mint App jwt
-set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} APP_TOKEN)
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 200
 GET test/app/secure /test 200
 
 # Wrong App jwt should return 401
-set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app02"} APP_TOKEN)
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app02"} <JWT_SECRET>app01)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 401
 GET test/app/secure /test 401

--- a/views/app.register.fg
+++ b/views/app.register.fg
@@ -37,7 +37,7 @@ sql.insert odin.app_user_installation_id_ledger {
     "identity_id": "installation_ref",
     "installation_id": "fred-mobile"
 }
-set app_jwt (odin.jwt.mint {"sub": "installation_ref", "iss": "http://odin.felspar.com/app/bowling-app"} B0wl1ng)
+set app_jwt (odin.jwt.mint {"sub": "installation_ref", "iss": "http://odin.felspar.com/app/bowling-app"} <JWT_SECRET>bowling-app)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 
 # Not pass the validation should return 422

--- a/views/app.register.test.json
+++ b/views/app.register.test.json
@@ -1,4 +1,7 @@
 {
+    "odin": {
+        "JWT secret": "<JWT_SECRET>"
+    },
     "webserver": {
         "views/odin/test/validate-register": {
             "view": "fostgres.sql",


### PR DESCRIPTION
We should use the JWT secret as the JWT token + application ID, but I forgot to edit the `odin.app.secure` load key function.