### PR TITLE
Fix the app.verify view that check the iss vs app_id doesn't have prefix

### DIFF
--- a/Cpp/odin-views/app.cpp
+++ b/Cpp/odin-views/app.cpp
@@ -292,7 +292,7 @@ namespace {
             }
             auto const iss = fostlib::coerce<fostlib::string>(
                     jwt.value().payload["iss"]);
-            if (iss != app_id) {
+            if (iss != odin::c_app_namespace.value() + app_id) {
                 throw fostlib::exceptions::not_implemented(
                         __PRETTY_FUNCTION__, "app_id mismatch");
             }

--- a/tests/app-verify.fg
+++ b/tests/app-verify.fg
@@ -56,18 +56,18 @@ POST odin/app /verify/app01/ {"random_key": "player1"} 501
 POST odin/app /verify/random_app/ {} 501
 POST odin/app /verify/app01/ {"token": "player1"} 501
 
-set user_jwt (odin.jwt.mint {"sub": "player1", "iss": "app01"} <JWT_SECRET>app01)
+set user_jwt (odin.jwt.mint {"sub": "player1", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set payload {}
 set-path payload ["token"] (lookup user_jwt)
 POST odin/app /verify/app01/ (lookup payload) 200 {"identity": {"id": "player1"}, "roles": ["pro-player"]}
 
-set user_jwt (odin.jwt.mint {"sub": "player3", "iss": "app01"} <JWT_SECRET>app01)
+set user_jwt (odin.jwt.mint {"sub": "player3", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set payload {}
 set-path payload ["token"] (lookup user_jwt)
 POST odin/app /verify/app01/ (lookup payload) 200 {"identity": {"id": "player3"}, "roles": []}
 
 # Use wrong app
-set user_jwt (odin.jwt.mint {"sub": "player1", "iss": "app02"} <JWT_SECRET>app02)
+set user_jwt (odin.jwt.mint {"sub": "player1", "iss": "http://odin.felspar.com/app/app02"} <JWT_SECRET>app02)
 set payload {}
 set-path payload ["token"] (lookup user_jwt)
 POST odin/app /verify/app01/ (lookup payload) 501


### PR DESCRIPTION
Forgot to add the `iss` namespace when validating it in app.verify view.