### PR TITLE
Feature/merge fix

### DIFF
--- a/Schema/core/002-add-merge-account.blue.sql
+++ b/Schema/core/002-add-merge-account.blue.sql
@@ -66,6 +66,10 @@ BEGIN
     DELETE FROM odin.identity WHERE id=NEW.from_identity_id;
     INSERT INTO odin.merge_record
         VALUES (NEW.from_identity_id, NEW.to_identity_id);
+    INSERT INTO odin.merge_record
+        SELECT from_identity_id, NEW.to_identity_id
+            FROM odin.merge_record
+            WHERE odin.merge_record.to_identity_id=NEW.from_identity_id;
     RETURN NEW;
 END;
 $body$

--- a/Schema/core/002-add-merge-account.blue.sql
+++ b/Schema/core/002-add-merge-account.blue.sql
@@ -26,8 +26,8 @@ CREATE TRIGGER identity_insert_trigger
     FOR EACH ROW
     EXECUTE PROCEDURE identity_insert();
 
---- For each ID records those records that have been merged to it. The
---- DAG for the merges is flattened it out. If `A -> B -> C` there will be
+--- For each ID record those records that have been merged to it. The
+--- DAG for the merges is flattened. If `A -> B -> C` there will be
 --- records for `A -> B`, `B -> C` and for `A -> C`.
 CREATE TABLE odin.merge_record(
     from_identity_id TEXT NOT NULL,

--- a/Schema/core/002-add-merge-account.blue.sql
+++ b/Schema/core/002-add-merge-account.blue.sql
@@ -28,8 +28,20 @@ CREATE TABLE odin.merge_record(
     FOREIGN KEY (from_identity_id) REFERENCES odin.identity_record(id),
     to_identity_id TEXT NOT NULL,
     FOREIGN KEY (to_identity_id) REFERENCES odin.identity_record(id),
-    PRIMARY KEY (from_identity_id, to_identity_id),
-    merged TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    PRIMARY KEY (from_identity_id, to_identity_id)
+);
+
+CREATE TABLE odin.merge_ledger(
+    from_identity_id TEXT NOT NULL,
+    FOREIGN KEY (from_identity_id) REFERENCES odin.identity_record(id),
+    to_identity_id TEXT NOT NULL,
+    FOREIGN KEY (to_identity_id) REFERENCES odin.identity_record(id),
+    instructed TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (from_identity_id, to_identity_id, instructed),
+
+    created timestamp with time zone NOT NULL DEFAULT now(),
+    pg_user text NOT NULL DEFAULT current_user,
+    annotation jsonb NOT NULL DEFAULT '{}'
 );
 
 CREATE FUNCTION odin.merge_account()
@@ -51,7 +63,7 @@ END;
 $body$
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = odin;
 
-CREATE TRIGGER insert_merge_record
-    AFTER INSERT ON odin.merge_record
+CREATE TRIGGER insert_merge_instruction
+    AFTER INSERT ON odin.merge_ledger
     FOR EACH ROW
     EXECUTE PROCEDURE odin.merge_account();

--- a/tests/merge-account-test.json
+++ b/tests/merge-account-test.json
@@ -9,30 +9,11 @@
                         "sql": [{
                             "return": "object",
                             "path": ["/merge_record", 1, 2],
-                            "GET": {
-                                "command": "SELECt * FROM odin.merge_record WHERE from_identity_id=$1 AND to_identity_id=$2;",
-                                "arguments": [1 ,2]
-                            },
-                            "PUT": {
-                                "table": "odin.merge_record",
-                                "columns": {
-                                    "from_identity_id": {
-                                        "key": true,
-                                        "source": 1
-                                    },
-                                    "to_identity_id": {
-                                        "key": true,
-                                        "source": 2
-                                    }                        
-                                }
-                            }
+                            "GET": "SELECt * FROM odin.merge_record WHERE from_identity_id=$1 AND to_identity_id=$2;"
                         }, {
                             "return": "object",
                             "path": ["/identity", 1],
-                            "GET": {
-                                "command": "SELECT * FROM odin.identity WHERE id=$1",
-                                "arguments": [1]
-                            }
+                            "GET":  "SELECT * FROM odin.identity WHERE id=$1"
                         }, {
                             "return": "object",
                             "path": ["/identity-record", 1],

--- a/tests/merge-account-test.json
+++ b/tests/merge-account-test.json
@@ -9,7 +9,25 @@
                         "sql": [{
                             "return": "object",
                             "path": ["/merge_record", 1, 2],
-                            "GET": "SELECt * FROM odin.merge_record WHERE from_identity_id=$1 AND to_identity_id=$2;"
+                            "GET": "SELECT * FROM odin.merge_record WHERE from_identity_id=$1 AND to_identity_id=$2;"
+                        }, {
+                            "return": "object",
+                            "path": ["/merge_ledger", 1, 2],
+                            "GET": "SELECT * FROM odin.merge_ledger
+                                WHERE from_identity_id=$1 AND to_identity_id=$2;",
+                            "PUT": {
+                                "table": "odin.merge_ledger",
+                                "columns": {
+                                    "from_identity_id": {
+                                        "key": true,
+                                        "source": 1
+                                    },
+                                    "to_identity_id": {
+                                        "key": true,
+                                        "source": 2
+                                    }
+                                }
+                            }
                         }, {
                             "return": "object",
                             "path": ["/identity", 1],

--- a/tests/merge-account.fg
+++ b/tests/merge-account.fg
@@ -55,6 +55,31 @@ sql.insert odin.merge_ledger {"from_identity_id": "core1", "to_identity_id": "co
 GET test/merge-account/validate /identity/core1 404
 GET test/merge-account/validate /identity-record/core1 200 {"id": "core1"}
 
+## Check that we get all merge records
+##      core1 -> core2
+##      core3 -> core4
+##      core4 -> core2
+odin.user core3
+odin.user core4
+sql.insert odin.merge_ledger {"from_identity_id": "core3", "to_identity_id": "core4"}
+sql.insert odin.merge_ledger {"from_identity_id": "core4", "to_identity_id": "core2"}
+GET test/merge-account/validate /merge_record/core1/core2 200
+GET test/merge-account/validate /merge_record/core3/core4 200
+GET test/merge-account/validate /merge_record/core4/core2 200
+## This should also mean that we have a record of `core3 -> core2`
+GET test/merge-account/validate /merge_record/core3/core2 200
+## Add a final merge and we should get a ton of new records
+odin.user core5
+sql.insert odin.merge_ledger {"from_identity_id": "core2", "to_identity_id": "core5"}
+## First the one for the merge we just did
+GET test/merge-account/validate /merge_record/core2/core5 200
+## And one for each of the previous merges
+GET test/merge-account/validate /merge_record/core1/core5 200
+GET test/merge-account/validate /merge_record/core3/core5 200
+GET test/merge-account/validate /merge_record/core4/core5 200
+GET test/merge-account/validate /merge_record/core3/core5 200
+
+
 # Test module AuthN
 # Case merge unregistered user with registered user
 odin.user authn1

--- a/tests/merge-account.fg
+++ b/tests/merge-account.fg
@@ -72,12 +72,14 @@ GET test/merge-account/validate /credentials/authn3 200
 GET test/merge-account/validate /credentials/authn4 200
 GET test/merge-account/validate /identity/authn3 200 {"id": "authn3"}
 GET test/merge-account/validate /identity-record/authn3 200 {"id": "authn3"}
-sql.insert odin.merge_ledger {"from_identity_id": "authn3", "to_identity_id": "authn4"}
+# TODO: Ideally we'd do this insert and catch the error rather than with the PUT
+# sql.insert odin.merge_ledger {"from_identity_id": "authn3", "to_identity_id": "authn4"}
+PUT test/merge-account/validate /merge_ledger/authn3/authn4 {} 500
 GET test/merge-account/validate /identity/authn3 200
 
 # Test module AuthZ
 
-# Test superuser metrix 
+# Test superuser matrix
 #                   superuser   non superuser
 #   superuser           500         500
 #   non superuser       500         200
@@ -87,25 +89,25 @@ odin.user authz1
 odin.user authz2
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz1", "superuser": false}
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz2", "superuser": true}
-PUT test/merge-account/validate /merge_record/authz1/authz2 {} 500
+PUT test/merge-account/validate /merge_ledger/authz1/authz2 {} 500
 # Case from superuser to non superuser
 odin.user authz3
 odin.user authz4
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz3", "superuser": true}
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz4", "superuser": false}
-PUT test/merge-account/validate /merge_record/authz3/authz4 {} 500
+PUT test/merge-account/validate /merge_ledger/authz3/authz4 {} 500
 # Case from non superuser to superuser
 odin.user authz5
 odin.user authz6
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz5", "superuser": true}
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz6", "superuser": true}
-PUT test/merge-account/validate /merge_record/authz5/authz6 {} 500
+PUT test/merge-account/validate /merge_ledger/authz5/authz6 {} 500
 # Case from superuser to superuser
 odin.user authz7
 odin.user authz8
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz7", "superuser": false}
 sql.insert odin.identity_superuser_ledger {"reference": "ref1", "identity_id": "authz8", "superuser": false}
-PUT test/merge-account/validate /merge_record/authz7/authz8 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "authz7", "to_identity_id": "authz8"}
 GET test/merge-account/validate /identity/authz7 404
 
 # Insert group
@@ -119,13 +121,13 @@ sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "gro
 sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "group3", "identity_id": "authz9", "member": true}
 sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "group2", "identity_id": "authz10", "member": true}
 sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "group3", "identity_id": "authz10", "member": true}
-PUT test/merge-account/validate /merge_record/authz9/authz10 {} 500
+PUT test/merge-account/validate /merge_ledger/authz9/authz10 {} 500
 # Case user has no duplicate group
 odin.user authz11
 odin.user authz12
 sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "group1", "identity_id": "authz11", "member": true}
 sql.insert odin.group_membership_ledger {"reference": "ref3", "group_slug": "group2", "identity_id": "authz12", "member": true}
-PUT test/merge-account/validate /merge_record/authz11/authz12 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "authz11", "to_identity_id": "authz12"}
 GET test/merge-account/validate /identity/authz7 404
 GET test/merge-account/validate /group-membership/authz11/group1 404
 GET test/merge-account/validate /group-membership/authz12/group1 200 {"group_slug": "group1", "identity_id": "authz12"}
@@ -151,7 +153,7 @@ sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app1", "identit
 sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app3", "identity_id": "app_user1"}
 sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app2", "identity_id": "app_user2"}
 sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app3", "identity_id": "app_user2"}
-PUT test/merge-account/validate /merge_record/app_user1/app_user2 {} 500
+PUT test/merge-account/validate /merge_ledger/app_user1/app_user2 {} 500
 # Case user has no duplicate app
 odin.user app_user3
 odin.user app_user4
@@ -159,7 +161,7 @@ sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app1", "identit
 sql.insert odin.app_user_ledger {"reference": "ref3", "app_id": "app2", "identity_id": "app_user4"}
 sql.insert odin.app_user_role_ledger {"reference": "ref4", "app_id": "app1", "identity_id": "app_user3", "role": "role1"}
 sql.insert odin.app_user_role_ledger {"reference": "ref4", "app_id": "app2", "identity_id": "app_user4", "role": "role2"}
-PUT test/merge-account/validate /merge_record/app_user3/app_user4 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "app_user3", "to_identity_id": "app_user4"}
 GET test/merge-account/validate /identity/app_user3 404
 GET test/merge-account/validate /app-user/app_user3/app1 404 
 GET test/merge-account/validate /app-user-role/app_user3/app1/role1 404 
@@ -175,7 +177,7 @@ odin.user t_email2
 sql.insert odin.identity_email_ledger {"reference": "ref1", "identity_id": "t_email1", "email": "t_email1@mail.com"}
 sql.insert odin.identity_email_ledger {"reference": "ref1", "identity_id": "t_email2", "email": "t_email2@mail.com"}
 GET test/merge-account/validate /identity/t_email2 200 {"id": "t_email2", "email": "t_email2@mail.com"}
-PUT test/merge-account/validate /merge_record/t_email1/t_email2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "t_email1", "to_identity_id": "t_email2"}
 GET test/merge-account/validate /identity/t_email1 404
 GET test/merge-account/validate /identity/t_email2 200 {"id": "t_email2", "email": "t_email2@mail.com"}
 
@@ -190,7 +192,7 @@ odin.user facebook3
 odin.user facebook4
 sql.insert odin.facebook_credentials_ledger {"reference": "ref2", "identity_id": "facebook3", "facebook_user_id": "fu3"}
 sql.insert odin.facebook_credentials_ledger {"reference": "ref2", "identity_id": "facebook4", "facebook_user_id": "fu4"}
-PUT test/merge-account/validate /merge_record/facebook3/facebook4 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "facebook3", "to_identity_id": "facebook4"}
 GET test/merge-account/validate /identity/facebook3 404
 GET test/merge-account/validate /facebook_credentials/facebook3/fu3 404
 GET test/merge-account/validate /facebook_credentials/facebook4/fu3 200 {"identity_id": "facebook4", "facebook_user_id": "fu3"}
@@ -210,7 +212,7 @@ GET test/merge-account/validate /credentials_password_ledger/forgot2 200 {
 }
 GET test/merge-account/validate /request_reset_password_ledger/ref2/forgot1@mail.com 200
 GET test/merge-account/validate /request_reset_password_ledger/ref3/forgot2@mail.com 200
-PUT test/merge-account/validate /merge_record/forgot1/forgot2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "forgot1", "to_identity_id": "forgot2"}
 GET test/merge-account/validate /request_reset_password_ledger/ref2/forgot1@mail.com 200
 GET test/merge-account/validate /request_reset_password_ledger/ref2/forgot2@mail.com 404
 GET test/merge-account/validate /request_reset_password_ledger/ref3/forgot2@mail.com 200
@@ -225,7 +227,7 @@ odin.user f_name2
 sql.insert odin.identity_full_name_ledger {"reference": "ref1", "identity_id": "f_name1", "full_name": "f1 l1"}
 sql.insert odin.identity_full_name_ledger {"reference": "ref1", "identity_id": "f_name2", "full_name": "f2 l2"}
 GET test/merge-account/validate /identity/f_name2 200 {"id": "f_name2", "full_name": "f2 l2"}
-PUT test/merge-account/validate /merge_record/f_name1/f_name2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "f_name1", "to_identity_id": "f_name2"}
 GET test/merge-account/validate /identity/f_name1 404
 GET test/merge-account/validate /identity/f_name2 200 {"id": "f_name2", "full_name": "f2 l2"}
 
@@ -240,7 +242,7 @@ odin.user google3
 odin.user google4
 sql.insert odin.google_credentials_ledger {"reference": "ref2", "identity_id": "google3", "google_user_id": "go3"}
 sql.insert odin.google_credentials_ledger {"reference": "ref2", "identity_id": "google4", "google_user_id": "go4"}
-PUT test/merge-account/validate /merge_record/google3/google4 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "google3", "to_identity_id": "google4"}
 GET test/merge-account/validate /identity/google3 404
 GET test/merge-account/validate /google_credentials/google3/go3 404
 GET test/merge-account/validate /google_credentials/google4/go3 200 {"identity_id": "google4", "google_user_id": "go3"}
@@ -253,7 +255,7 @@ odin.user install2
 sql.insert odin.identity_installation_id_ledger {"reference": "ref1", "identity_id": "install1", "installation_id": "il001"}
 sql.insert odin.identity_installation_id_ledger {"reference": "ref1", "identity_id": "install2", "installation_id": "il002"}
 GET test/merge-account/validate /identity/install2 200 {"id": "install2", "installation_id": "il002"}
-PUT test/merge-account/validate /merge_record/install1/install2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "install1", "to_identity_id": "install2"}
 GET test/merge-account/validate /identity/install1 404
 GET test/merge-account/validate /identity/install2 200 {"id": "install2", "installation_id": "il002"}
 
@@ -265,6 +267,6 @@ sql.insert odin.logout_ledger {"reference": "ref1", "identity_id": "logout1"}
 sql.insert odin.logout_ledger {"reference": "ref1", "identity_id": "logout2"}
 sql.insert odin.logout_ledger {"reference": "ref2", "identity_id": "logout2"}
 GET test/merge-account/validate /credentials/logout2 200 {"identity_id": "logout2", "logout_count": 2}
-PUT test/merge-account/validate /merge_record/logout1/logout2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "logout1", "to_identity_id": "logout2"}
 GET test/merge-account/validate /identity/logout1 404
 GET test/merge-account/validate /credentials/logout2 200 {"identity_id": "logout2", "logout_count": 2}

--- a/tests/merge-account.fg
+++ b/tests/merge-account.fg
@@ -51,7 +51,7 @@ odin.user core1
 odin.user core2
 GET test/merge-account/validate /identity/core1 200 {"id": "core1"}
 GET test/merge-account/validate /identity-record/core1 200 {"id": "core1"}
-PUT test/merge-account/validate /merge_record/core1/core2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "core1", "to_identity_id": "core2"}
 GET test/merge-account/validate /identity/core1 404
 GET test/merge-account/validate /identity-record/core1 200 {"id": "core1"}
 
@@ -63,7 +63,7 @@ GET test/merge-account/validate /credentials/authn1 404
 GET test/merge-account/validate /credentials/authn2 200
 GET test/merge-account/validate /identity/authn1 200 {"id": "authn1"}
 GET test/merge-account/validate /identity-record/authn1 200 {"id": "authn1"}
-PUT test/merge-account/validate /merge_record/authn1/authn2 {} 200
+sql.insert odin.merge_ledger {"from_identity_id": "authn1", "to_identity_id": "authn2"}
 GET test/merge-account/validate /identity/authn1 404
 # Case merge registered user with registered user
 odin.user authn3 password123
@@ -72,7 +72,7 @@ GET test/merge-account/validate /credentials/authn3 200
 GET test/merge-account/validate /credentials/authn4 200
 GET test/merge-account/validate /identity/authn3 200 {"id": "authn3"}
 GET test/merge-account/validate /identity-record/authn3 200 {"id": "authn3"}
-PUT test/merge-account/validate /merge_record/authn3/authn4 {} 500
+sql.insert odin.merge_ledger {"from_identity_id": "authn3", "to_identity_id": "authn4"}
 GET test/merge-account/validate /identity/authn3 200
 
 # Test module AuthZ


### PR DESCRIPTION
This separates the merge records from the merge instructions. It also places merge records for each of the previously merged records, so a graph like `A -> B -> C` will show all of `A -> B`, `B -> C` *and* `A -> C`.