### PR TITLE
Abandon unregistered user if the merge failed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-01-31  Tle Ekkul  <e.aryuth@gmail.com>
+  Abandon unregister user when merge failed
+
 2019-01-29  Tle Ekkul  <e.aryuth@gmail.com>
   Fix merge_record failed when user has app installation record
   Trigger merge account when user token and login mismatch

--- a/tests/app.mint.fg
+++ b/tests/app.mint.fg
@@ -34,3 +34,6 @@ set-path testserver.headers ["__user"] "bowling01"
 POST test/app/mint / {"username": "fred", "password": "password1234"} 200
 GET test/app/mint/validate /identity/bowling01 404
 GET test/app/mint/validate /merge_record/bowling01/fred 200
+
+# If the merge failed, just returns the identity_id that corresponse with the credentials
+POST test/app/mint / {"username": "fred", "password": "password1234"} 200


### PR DESCRIPTION
Abandoning unregistered user if the merge is failed.

We have a case that user already login and merge happened once, then that user has new unregister user and try to log in again. The merge will be failed because the merge function for app module will raise the unique violation constraints, which I think it's correct behavior. We should abandon the new unregistered user and returns them the registered one.

Flows
- User open the game, the game generates unregistered user
- User play games, get items, etc.
- User logs in, merge unregistered to their identity.

- The user opens the game in another device, the game generates unregistered user.
- User play games again, get items.
- User logs in, they will get the first game data instead.
