### PR TITLE
Feature/fix odin setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 import os
 from distutils.core import setup
 
-datadir = os.path.join('Schema')
+datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'Schema')
 datafiles = [(os.path.join('share', 'odin', d), [os.path.join(d,f) for f in files])
-    for d, folders, files in os.walk(datadir)]
+    for d, folders, files in os.walk(datadir) if [f for f in files if f.endswith('.sql')]]
 
 setup(name='odin',
-        version='0.1.6.2',
+        version='0.1.6.3',
         description='Odin security system',
         author='Kirt Saelensminde',
         author_email='kirit@proteus-tech.com',

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@
 import os
 from distutils.core import setup
 
-datadir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'Schema')
-datafiles = [(os.path.join('share', 'odin', d), [os.path.join(d,f) for f in files])
-    for d, folders, files in os.walk(datadir) if [f for f in files if f.endswith('.sql')]]
+datafiles = [(os.path.join('share', 'odin', d), [os.path.join(d,f) for f in files if f.endswith('.sql')])
+    for d, folders, files in os.walk('Schema')]
 
 setup(name='odin',
         version='0.1.6.3',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 from distutils.core import setup
 
+datadir = os.path.join('Schema')
+datafiles = [(os.path.join('share', 'odin', d), [os.path.join(d,f) for f in files])
+    for d, folders, files in os.walk(datadir)]
+
 setup(name='odin',
         version='0.1.6.2',
         description='Odin security system',
@@ -11,26 +15,5 @@ setup(name='odin',
         packages=['odin'],
         package_dir={'': 'Python'},
         install_requires=['psycopg2-binary'],
-        data_files=[
-            ('share/odin/Schema', ['Schema/bootstrap.sql']),
-            ('share/odin/Schema/authn', ['Schema/authn/001-initial.blue.sql']),
-            ('share/odin/Schema/authz', [
-                'Schema/authz/001-initial.blue.sql',
-                'Schema/authz/002-view-user_permission.blue.sql']),
-            ('share/odin/Schema/core', ['Schema/core/000-initial.blue.sql']),
-            ('share/odin/Schema/opts/full-name', ['Schema/opts/full-name/001-initial.blue.sql']),
-            ('share/odin/Schema/opts/email', ['Schema/opts/email/001-initial.blue.sql']),
-            ('share/odin/Schema/opts/forgotten-password', ['Schema/opts/forgotten-password/001-initial.blue.sql']),
-            ('share/odin/Schema/opts/facebook', ['Schema/opts/facebook/001-initial.blue.sql']),
-            ('share/odin/Schema/opts/google', ['Schema/opts/google/001-initial.blue.sql']),
-            ('share/odin/Schema/opts/installation-id', [
-                'Schema/opts/installation-id/001-initial.blue.sql'
-            ]),
-            ('share/odin/Schema/app', [
-                'Schema/app/002-initial.blue.sql', 'Schema/app/003-app-role.blue.sql', 
-                'Schema/app/004-app-installation.blue.sql']),
-            ('share/odin/Schema/opts/logout', [
-                'Schema/opts/logout/002-initial.blue.sql',
-                'Schema/opts/logout/003-fix-logout-count.blue.sql']),
-        ],
+        data_files=datafiles,
      )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 from distutils.core import setup
 
 datadir = os.path.join('Schema')


### PR DESCRIPTION
we have missing data_files when pip install odin. I make it automatically walk through the Schema directory and generate the data_files for us.

The problem is now it's still including the CMakeLists.txt and README.md along with sql files.
But I think it's OK.