### PR TITLE
JWTs in cookies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-08-27  Kirit Saelensminde  <kirit@felspar.com>
+ JWTs may be placed in cookies and decoded from there.
+
 2019-08-08  Pattarawut Imamnuaysup  <pattarawut@hot-now.com>
  Add support for password hashing process in an array
 

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -24,6 +24,10 @@ namespace {
             fostlib::pg::connection &cnx,
             fostlib::json jwt_header,
             fostlib::json jwt_body) {
+        if (not jwt_body.has_key("iss")) {
+            throw fostlib::exceptions::not_implemented(
+                    __PRETTY_FUNCTION__, "No issuer in the JWT");
+        }
         auto const jwt_iss = fostlib::coerce<fostlib::string>(jwt_body["iss"]);
         if (jwt_iss.find(odin::c_app_namespace.value()) == std::string::npos) {
             throw fostlib::exceptions::not_implemented(

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -56,6 +56,7 @@ namespace {
                 app_token.data().begin(), app_token.data().end());
     }
 
+
     const class app_secure : public fostlib::urlhandler::view {
       public:
         app_secure() : view("odin.app.secure") {}
@@ -98,6 +99,33 @@ namespace {
             return execute(config["unsecure"], path, req, host);
         }
     } c_app_secure;
+
+
+    const class app_secure_cookie : public fostlib::urlhandler::view {
+      public:
+        app_secure_cookie() : view("odin.app.secure.cookie") {}
+
+        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+                const fostlib::json &config,
+                const fostlib::string &path,
+                fostlib::http::server::request &req,
+                const fostlib::host &host) const {
+            auto cookies = req.headers()["Cookie"];
+            fostlib::parse_cookies(cookies);
+            if (not config.has_key("cookie")) {
+                throw fostlib::exceptions::not_implemented{
+                        __PRETTY_FUNCTION__,
+                        "Configuration item 'cookie' must be specified"};
+            }
+            auto rawjwt = cookies.subvalue(
+                    fostlib::coerce<f5::u8view>(config["cookie"]));
+            throw fostlib::exceptions::not_implemented{
+                    __PRETTY_FUNCTION__,
+                    cookies.subvalue("test-auth-cookie").value_or("**")};
+        }
+    } c_app_secure_cookie;
+
+
 }
 
 

--- a/Cpp/odin-views/app_secure.cpp
+++ b/Cpp/odin-views/app_secure.cpp
@@ -19,21 +19,6 @@
 
 namespace {
 
-    std::optional<fostlib::string>
-            bearer_jwt(fostlib::http::server::request const &req) {
-        if (req.headers().exists("Authorization")) {
-            auto parts = fostlib::partition(
-                    req.headers()["Authorization"].value(), " ");
-            if (parts.first == "Bearer" && parts.second) {
-                return parts.second;
-            } else {
-                fostlib::log::warning(odin::c_odin)(
-                        "", "Invalid Authorization scheme")(
-                        "scheme", parts.first)("data", parts.second);
-            }
-        }
-        return {};
-    }
 
     std::vector<f5::byte> load_key(
             fostlib::pg::connection &cnx,
@@ -57,16 +42,32 @@ namespace {
     }
 
 
-    const class app_secure : public fostlib::urlhandler::view {
+    /**
+     * Base class used to handle the JWT code. It assumes that there are
+     * a variety of ways of getting at the JWT value itself.
+     */
+    class jwt_secure : public fostlib::urlhandler::view {
       public:
-        app_secure() : view("odin.app.secure") {}
+        jwt_secure(f5::u8view n) : view(n) {}
+
+        /// Must be implemented to load the actual JWT itself
+        virtual std::optional<fostlib::string> find_jwt(
+                const fostlib::json &config,
+                fostlib::http::server::request const &req) const = 0;
 
         std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
                 const fostlib::json &config,
                 const fostlib::string &path,
                 fostlib::http::server::request &req,
                 const fostlib::host &host) const {
-            auto const jwt_body = bearer_jwt(req);
+            auto const jwt_body = find_jwt(config, req);
+            if (not config.has_key("secure")
+                || not config.has_key("unsecure")) {
+                throw fostlib::exceptions::not_implemented{
+                        __PRETTY_FUNCTION__,
+                        "Configuration must contain both `secure` and "
+                        "`unsecure` views"};
+            }
             if (jwt_body) {
                 fostlib::pg::connection cnx{fostgres::connection(config, req)};
                 auto jwt = fostlib::jwt::token::load(
@@ -98,18 +99,39 @@ namespace {
             }
             return execute(config["unsecure"], path, req, host);
         }
+    };
+
+
+    const class app_secure : public jwt_secure {
+      public:
+        app_secure() : jwt_secure("odin.app.secure") {}
+
+        std::optional<fostlib::string> find_jwt(
+                const fostlib::json &,
+                fostlib::http::server::request const &req) const {
+            if (req.headers().exists("Authorization")) {
+                auto parts = fostlib::partition(
+                        req.headers()["Authorization"].value(), " ");
+                if (parts.first == "Bearer" && parts.second) {
+                    return parts.second;
+                } else {
+                    fostlib::log::warning(odin::c_odin)(
+                            "", "Invalid Authorization scheme")(
+                            "scheme", parts.first)("data", parts.second);
+                }
+            }
+            return {};
+        }
     } c_app_secure;
 
 
-    const class app_secure_cookie : public fostlib::urlhandler::view {
+    const class app_secure_cookie : public jwt_secure {
       public:
-        app_secure_cookie() : view("odin.app.secure.cookie") {}
+        app_secure_cookie() : jwt_secure("odin.app.secure.cookie") {}
 
-        std::pair<boost::shared_ptr<fostlib::mime>, int> operator()(
+        std::optional<fostlib::string> find_jwt(
                 const fostlib::json &config,
-                const fostlib::string &path,
-                fostlib::http::server::request &req,
-                const fostlib::host &host) const {
+                fostlib::http::server::request const &req) const {
             auto cookies = req.headers()["Cookie"];
             fostlib::parse_cookies(cookies);
             if (not config.has_key("cookie")) {
@@ -117,11 +139,8 @@ namespace {
                         __PRETTY_FUNCTION__,
                         "Configuration item 'cookie' must be specified"};
             }
-            auto rawjwt = cookies.subvalue(
+            return cookies.subvalue(
                     fostlib::coerce<f5::u8view>(config["cookie"]));
-            throw fostlib::exceptions::not_implemented{
-                    __PRETTY_FUNCTION__,
-                    cookies.subvalue("test-auth-cookie").value_or("**")};
         }
     } c_app_secure_cookie;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,6 +234,35 @@ if(TARGET stress OR TARGET pgtest)
                 permissions-test-view.json
         )
 
+    add_custom_command(OUTPUT test-permissions-cookie
+            COMMAND fostgres-test odin-test-permissions-cookie -o test-permissions-cookie
+                $<TARGET_SONAME_FILE:odin-fg>
+                $<TARGET_SONAME_FILE:odin-views>
+                ${CMAKE_CURRENT_SOURCE_DIR}/../Schema/bootstrap.sql
+                ${CMAKE_CURRENT_SOURCE_DIR}/../Configuration/odin-views.json
+                ${CMAKE_CURRENT_SOURCE_DIR}/permissions-test-view.cookie.json
+                ${CMAKE_CURRENT_SOURCE_DIR}/permissions.cookie.fg
+            MAIN_DEPENDENCY permissions.cookie.fg
+            DEPENDS
+                fostgres-test
+                fostgres
+                odin-fg
+                odin-views
+                ../Schema/bootstrap.sql
+                ../Schema/core/000-initial.blue.sql
+                ../Schema/core/002-add-merge-account.blue.sql
+                ../Schema/authn/001-initial.blue.sql
+                ../Schema/authn/002-fix-login.blue.sql
+                ../Schema/authn/003-alter-ledgers.blue.sql
+                ../Schema/authz/001-initial.blue.sql
+                ../Schema/authz/002-view-user_permission.blue.sql
+                ../Schema/authz/003-alter-ledgers.blue.sql
+                ../Schema/authz/004-merge-account-function.blue.sql
+                ../Configuration/odin-views.json
+                permissions.cookie.fg
+                permissions-test-view.cookie.json
+        )
+
     add_custom_command(OUTPUT test-registration-self
             COMMAND fostgres-test odin-test-registration-self -o test-registration-self
                 $<TARGET_SONAME_FILE:odin-fg>
@@ -800,6 +829,7 @@ if(TARGET stress OR TARGET pgtest)
             test-no-auth
             test-password
             test-permissions
+            test-permissions-cookie
             test-registration-self
             test-session
             test-forgotten-password

--- a/tests/app-secure-test-view.json
+++ b/tests/app-secure-test-view.json
@@ -22,6 +22,25 @@
                     }
                 }
             }
+        },
+        "views/test/app/secure/cookie": {
+            "view": "odin.app.secure.cookie",
+            "configuration": {
+                "cookie": "test-auth-cookie",
+                "secure": {
+                    "view": "fost.view.pathprefix",
+                    "configuration": {
+                        "": "fost.response.200",
+                        "test/": "fost.response.201"
+                    }
+                },
+                "unsecure": {
+                    "view": "fost.response.302",
+                    "configuration": {
+                        "location": "https://example.com/login"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -87,3 +87,15 @@ set-path testserver.cookies ["test"] abcdefg
 set-path testserver.cookies ["test-cookie"] hijklmn
 GET test/app/secure/cookie / 200
 GET test/app/secure/cookie /test 200
+
+## Wrong App jwt should return 401
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app02"} <JWT_SECRET>app01)
+set-path testserver.cookies ["test-auth-cookie"] (lookup app_jwt)
+GET test/app/secure/cookie / 302
+GET test/app/secure/cookie /test 302
+
+## Should return not implemented if iss doesn't prefix with app namespace
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "app02"} APP_TOKEN)
+set-path testserver.cookies ["test-auth-cookie"] (lookup app_jwt)
+GET test/app/secure/cookie / 501
+GET test/app/secure/cookie /test 501

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -88,7 +88,7 @@ set-path testserver.cookies ["test-cookie"] hijklmn
 GET test/app/secure/cookie / 200
 GET test/app/secure/cookie /test 200
 
-## Wrong App jwt should return 401
+## Wrong App jwt should return 302
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app02"} <JWT_SECRET>app01)
 set-path testserver.cookies ["test-auth-cookie"] (lookup app_jwt)
 GET test/app/secure/cookie / 302

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -42,6 +42,8 @@ sql.insert odin.app_ledger {
 
 GET test/app/secure / 401
 
+## ## Bearer Authorization header
+
 # Mint App jwt
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
@@ -60,3 +62,22 @@ set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 501
 GET test/app/secure /test 501
 
+# ## Cookies
+
+# Clear the app JWT before retrying everything with cookies
+rm-path testserver.headers ["Authorization"]
+GET test/app/secure / 401
+GET test/app/secure /test 401
+
+## View config errors
+GET {"view": "odin.app.secure.cookie"} / 501
+GET {
+        "view": "odin.app.secure.cookie",
+        "configuration": {"cookie": "cookie-name"}
+    } / 501
+
+# Get a valid JWT and set it as a cookie value
+set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
+set-path testserver.cookies ["test-auth-cookie"] (lookup app_jwt)
+#GET test/app/secure/cookie / 200
+#GET test/app/secure/cookie /test 200

--- a/tests/app-secure.fg
+++ b/tests/app-secure.fg
@@ -1,4 +1,4 @@
-# Set up the database
+## Set up the database
 odin.sql.file (module.path.join ../Schema/core/000-initial.blue.sql)
 odin.sql.file (module.path.join ../Schema/core/002-add-merge-account.blue.sql)
 odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
@@ -10,13 +10,13 @@ odin.sql.file (module.path.join ../Schema/app/004-app-installation.blue.sql)
 odin.sql.file (module.path.join ../Schema/app/005-alter-ledgers.blue.sql)
 odin.sql.file (module.path.join ../Schema/app/006-merge-account-function.blue.sql)
 
-# Set up new users and apps
+## Set up new users and apps
 odin.user owner owner password1234
 odin.user player1 player1 password1234
 odin.user player2 player2 password1234
 odin.user player3 player3 password1234
 
-# Register app01
+## Register app01
 sql.insert odin.identity {"id": "app01"}
 sql.insert odin.app_ledger {
     "reference": "ref1",
@@ -28,7 +28,7 @@ sql.insert odin.app_ledger {
     "data_sharing_policy": "ALL"
 }
 
-# Register app02
+## Register app02
 sql.insert odin.identity {"id": "app02"}
 sql.insert odin.app_ledger {
     "reference": "ref1",
@@ -44,27 +44,27 @@ GET test/app/secure / 401
 
 ## ## Bearer Authorization header
 
-# Mint App jwt
+## Mint App jwt
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 200
 GET test/app/secure /test 200
 
-# Wrong App jwt should return 401
+## Wrong App jwt should return 401
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app02"} <JWT_SECRET>app01)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 401
 GET test/app/secure /test 401
 
-# Should return not implemented if iss doesn't prefix with app namespace
+## Should return not implemented if iss doesn't prefix with app namespace
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "app02"} APP_TOKEN)
 set-path testserver.headers ["Authorization"] (cat "Bearer " (lookup app_jwt))
 GET test/app/secure / 501
 GET test/app/secure /test 501
 
-# ## Cookies
+## ## Cookies
 
-# Clear the app JWT before retrying everything with cookies
+## Clear the app JWT before retrying everything with cookies
 rm-path testserver.headers ["Authorization"]
 GET test/app/secure / 401
 GET test/app/secure /test 401
@@ -76,8 +76,14 @@ GET {
         "configuration": {"cookie": "cookie-name"}
     } / 501
 
-# Get a valid JWT and set it as a cookie value
+## Get a valid JWT and set it as a cookie value
 set app_jwt (odin.jwt.mint {"sub": "some_user", "iss": "http://odin.felspar.com/app/app01"} <JWT_SECRET>app01)
 set-path testserver.cookies ["test-auth-cookie"] (lookup app_jwt)
-#GET test/app/secure/cookie / 200
-#GET test/app/secure/cookie /test 200
+GET test/app/secure/cookie / 200
+GET test/app/secure/cookie /test 200
+
+## Other cookies are ignored
+set-path testserver.cookies ["test"] abcdefg
+set-path testserver.cookies ["test-cookie"] hijklmn
+GET test/app/secure/cookie / 200
+GET test/app/secure/cookie /test 200

--- a/tests/permissions-test-view.cookie.json
+++ b/tests/permissions-test-view.cookie.json
@@ -1,0 +1,38 @@
+{
+    "webserver": {
+        "views/test/permission": {
+            "view": "odin.secure.cookie",
+            "configuration": {
+                "cookie": "test-auth-cookie",
+                "secure": {
+                    "view": "fost.view.pathprefix",
+                    "configuration": {
+                        "": "odin/secure/sql",
+                        "create-group/": {
+                            "view": "odin.permission",
+                            "configuration": {
+                                "permission": "create-group",
+                                "allowed": "odin/secure/sql",
+                                "forbidden": "fost.response.403"
+                            }
+                        },
+                        "not-granted/": {
+                            "view": "odin.permission",
+                            "configuration": {
+                                "permission": "not-granted",
+                                "allowed": "odin/secure/sql",
+                                "forbidden": "fost.response.403"
+                            }
+                        }
+                    }
+                },
+                "unsecure": {
+                    "view": "fost.response.302",
+                    "configuration": {
+                        "location": "http://example.com/login"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/permissions.cookie.fg
+++ b/tests/permissions.cookie.fg
@@ -1,0 +1,37 @@
+## These are the same tests as found in [`permission.fg`](./permission.fg),
+## but secured with a cookie rather than the `Authorization` header with
+## `Bearer`
+
+# Set up the database
+odin.sql.file (module.path.join ../Schema/core/000-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/core/002-add-merge-account.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/001-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/002-fix-login.blue.sql)
+odin.sql.file (module.path.join ../Schema/authn/003-alter-ledgers.blue.sql)
+odin.sql.file (module.path.join ../Schema/authz/001-initial.blue.sql)
+odin.sql.file (module.path.join ../Schema/authz/002-view-user_permission.blue.sql)
+odin.sql.file (module.path.join ../Schema/authz/003-alter-ledgers.blue.sql)
+odin.sql.file (module.path.join ../Schema/authz/004-merge-account-function.blue.sql)
+setting odin "Trust JWT" true
+
+# Set up test permissions and group
+odin.permission test-perm "Test permission"
+odin.permission not-granted "Another permission"
+odin.group public "Public access"
+odin.assign public test-perm create-group
+
+# When not logged in get a 302
+GET test/permission /not-granted/ 302
+
+# Set up a user account
+odin.user test-user test-user password1234
+odin.membership test-user public
+set-path testserver.cookies ["test-auth-cookie"] (odin.jwt.mint {"sub": "test-user"})
+
+# Check the right permissions are granted
+GET test/permission /me/permissions 200 {"columns": ["permission"],
+    "rows": [["create-group"], ["test-perm"]]}
+
+# Check the web API is also able to check the permissions
+GET test/permission /create-group/ 200
+GET test/permission /not-granted/ 403


### PR DESCRIPTION
Cookies can be used to store the JWT used for securing a site.
